### PR TITLE
Use smaller stack-sims docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsstdesc/stack-sims:w_2019_42-sims_w_2019_42
+FROM lsstdesc/stack-sims:w_2019_42-sims_w_2019_42-v2
 
 USER root
 RUN mkdir -p /DC2 &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set +e &&\
   git checkout v0.6.0 &&\
   scons &&\
   cd ../DESC_DC2_imSim_Workflow &&\
-  git checkout Run2.2i-validation
+  git checkout Run2.2i-validation-v2
 ENTRYPOINT ["/DC2/DESC_DC2_imSim_Workflow/docker_run.sh"]
 CMD ["echo You must specify a command to run inside the LSST ALCF container"]
 

--- a/scripts/run_imsim.py
+++ b/scripts/run_imsim.py
@@ -7,9 +7,9 @@ import json
 
 import galsim
 import desc.imsim
-#from astropy.utils import iers
-#iers.conf.auto_download = False
-#iers.conf.auto_max_age = None
+from astropy.utils import iers
+iers.conf.auto_download = False
+iers.conf.auto_max_age = None
 
 #galsim.meta_data.share_dir = '/opt/lsst/software/stack/stack/miniconda3-4.5.4-fcd27eb/Linux64/galsim/2.1.4.lsst/share/galsim'
 galsim.meta_data.share_dir = '/opt/lsst/software/stack/stack/miniconda3-4.5.12-1172c30/Linux64/galsim/2.2.1.lsst/share/galsim'


### PR DESCRIPTION
We need the stack-sims docker image to be < 5 GB on dockerhub to support use of Travis for imSim CI.
It would be great to get this in sooner rather than later.