### PR TITLE
Move to imSim v0.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN set +e &&\
   git clone https://github.com/LSSTDESC/DESC_DC2_imSim_Workflow.git &&\
   setup -r imSim -j &&\
   cd imSim &&\
-  git checkout v0.6.0 &&\
+  git checkout v0.6.1 &&\
   scons &&\
   cd ../DESC_DC2_imSim_Workflow &&\
   git checkout Run2.2i-validation-v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set +e &&\
   git checkout v0.6.1 &&\
   scons &&\
   cd ../DESC_DC2_imSim_Workflow &&\
-  git checkout Run2.2i-validation-v2
+  git checkout Run2.2i-validation-v3
 ENTRYPOINT ["/DC2/DESC_DC2_imSim_Workflow/docker_run.sh"]
 CMD ["echo You must specify a command to run inside the LSST ALCF container"]
 

--- a/parsl_imsim_configs
+++ b/parsl_imsim_configs
@@ -51,3 +51,7 @@ sort_magnorm = True
 # AtmosphericPSF + OptWF PSF to account for additional instrumental
 # effects.
 gaussianFWHM = 0.4
+
+[iers_download]
+disable = True
+iers_file = 19-10-30-finals2000A.all


### PR DESCRIPTION
Updates IERS handling to use local cache.  It appears the default is to disable remote downloads of the IERS data.